### PR TITLE
Plaintext charset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,47 @@ Usage
 ---------------------
 
 ```
-  xortool [-h|--help] [OPTIONS] [<filename>]
+xortool
+  A tool to do some xor analysis:
+  - guess the key length (based on count of equal chars)
+  - guess the key (base on knowledge of most frequent char)
+
+Usage:
+  xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
+  xortool [-h | --help]
+  xortool --version
+
 Options:
-  -l,--key-length       length of the key (integer)
-  -c,--char             most possible char (one char or hex code)
-  -m,--max-keylen=32    maximum key length to probe (integer)
-  -x,--hex              input is hex-encoded str
-  -b,--brute-chars      brute-force all possible characters
-  -o,--brute-printable  same as -b but will only use printable
-                        characters for keys
+  -x --hex                          input is hex-encoded str
+  -l LEN, --key-length=LEN          length of the key
+  -m MAX-LEN, --max-keylen=MAX-LEN  maximum key length to probe [default: 65]
+  -c CHAR, --char=CHAR              most frequent char (one char or hex code)
+  -b --brute-chars                  brute force all possible most frequent chars
+  -o --brute-printable              same as -b but will only check printable chars
+  -f --filter-output                filter outputs based on the charset
+  -t CHARSET --text-charset=CHARSET target text character set [default: printable]
+  -h --help                         show this help
+
+Notes:
+  Text character set:
+    * Pre-defined sets: printable, base32, base64
+    * Custom sets:
+      - a: lowercase chars
+      - A: uppercase chars
+      - 1: digits
+      - !: special chars
+      - *: printable chars
+
+Examples:
+  xortool file.bin
+  xortool -l 11 -c 20 file.bin
+  xortool -x -c ' ' file.hex
+  xortool -b -f -l 23 -t base64 message.enc
 ```
 
-Example
+Example 1
 ---------------------
 
 ```bash
@@ -101,6 +130,48 @@ So, if automated decryption fails, you can calibrate:
 - (`-m`) max length to try longer keys
 - (`-l`) selected length to see some interesting keys
 - (`-c`) the most frequent char to produce right plaintext
+
+Example 2
+---------------------
+
+We are given a message in encoded in Base64 and XORed with an unknown key.
+
+```bash
+# xortool message.enc 
+The most probable key lengths:
+   2:   12.3%
+   4:   13.8%
+   6:   10.5%
+   8:   11.5%
+  10:   8.6%
+  12:   9.4%
+  14:   7.1%
+  16:   7.8%
+  23:   10.4%
+  46:   8.7%
+Key-length can be 4*n
+Most possible char is needed to guess the key!
+```
+
+We can now test the key lengths while filtering the outputs so that it only keeps the plaintexts holding the character set of Base64. After trying a few lengths, we come to the right one, which gives only 1 plaintext with a percentage of valid characters above the default threshold of 95%.
+
+```bash
+$ xortool message.enc -b -f -l 23 -t base64
+256 possible key(s) of length 23:
+\x01=\x121#"0\x17\x13\t\x7f ,&/\x12s\x114u\x170#
+\x00<\x130"#1\x16\x12\x08~!-\'.\x13r\x105t\x161"
+\x03?\x103! 2\x15\x11\x0b}".$-\x10q\x136w\x152!
+\x02>\x112 !3\x14\x10\n|#/%,\x11p\x127v\x143 
+\x059\x165\'&4\x13\x17\r{$("+\x16w\x150q\x134\'
+...
+Found 1 plaintexts with 95.0%+ valid characters
+See files filename-key.csv, filename-char_used-perc_valid.csv
+```
+
+By filtering the outputs on the character set of Base64, we directly keep the only solution.
+
+Information
+---------------------
 
 Author: hellman ( hellman1908@gmail.com )
 

--- a/xortool/args.py
+++ b/xortool/args.py
@@ -4,6 +4,7 @@
 from docopt import docopt
 
 from xortool.routine import parse_char
+from xortool.charset import get_charset
 
 
 class ArgError(Exception):
@@ -21,8 +22,10 @@ def parse_parameters(doc, version):
             "most_frequent_char": parse_char(p["char"]) if p["char"] else None,
             "brute_chars": bool(p["brute-chars"]),
             "brute_printable": bool(p["brute-printable"]),
+            "text_charset": get_charset(p["text-charset"]),
             "frequency_spread": 0,  # to be removed
             "filename": p["FILE"] if p["FILE"] else "-",  # stdin by default
+            "filter_output": bool(p["filter-output"]),
         }
     except ValueError as err:
         raise ArgError(str(err))

--- a/xortool/charset.py
+++ b/xortool/charset.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+import string
+
+
+class CharsetError(Exception):
+    pass
+
+
+CHARSETS = {
+    "a": string.ascii_lowercase,
+    "A": string.ascii_uppercase,
+    "1": string.digits,
+    "!": string.punctuation,
+    "*": string.printable,
+}
+
+PREDEFINED_CHARSETS = {
+    "base32":    CHARSETS["A"] + "234567=",
+    "base64":    CHARSETS["a"] + CHARSETS["A"] + CHARSETS["1"] + "/+=",
+    "printable": CHARSETS["*"],
+}
+
+
+def get_charset(charset):
+    charset = charset or "printable"
+    if charset in PREDEFINED_CHARSETS.keys():
+        return PREDEFINED_CHARSETS[charset]
+    try:
+        _ = ""
+        for c in set(charset):
+            _ += CHARSETS[c]
+        return _
+    except KeyError as err:
+        raise CharsetError("Bad character set")

--- a/xortool/xortool
+++ b/xortool/xortool
@@ -7,9 +7,9 @@ xortool
   - guess the key (base on knowledge of most frequent char)
 
 Usage:
-  xortool [-x] [-m MAX-LEN] [FILE]
-  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [FILE]
-  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [FILE]
+  xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
   xortool [-h | --help]
   xortool --version
 
@@ -20,12 +20,25 @@ Options:
   -c CHAR, --char=CHAR              most frequent char (one char or hex code)
   -b --brute-chars                  brute force all possible most frequent chars
   -o --brute-printable              same as -b but will only check printable chars
+  -f --filter-output                filter outputs based on the charset
+  -t CHARSET --text-charset=CHARSET target text character set [default: printable]
   -h --help                         show this help
+
+Notes:
+  Text character set:
+    * Pre-defined sets: printable, base32, base64
+    * Custom sets:
+      - a: lowercase chars
+      - A: uppercase chars
+      - 1: digits
+      - !: special chars
+      - *: printable chars
 
 Examples:
   xortool file.bin
   xortool -l 11 -c 20 file.bin
   xortool -x -c ' ' file.hex
+  xortool -b -f -l 23 -t base64 message.enc
 """
 
 from operator import itemgetter
@@ -303,13 +316,14 @@ def print_keys(keys):
 
 
 # -----------------------------------------------------------------------------
-# RETURNS PERCENTAGE OF PRINTABLE CHARS
+# RETURNS PERCENTAGE OF VALID TEXT CHARS
 # -----------------------------------------------------------------------------
 
-def percentage_printable(text):
+def percentage_valid(text):
+    global PARAMETERS
     x = 0.0
     for c in text:
-        if c in string.printable:
+        if c in PARAMETERS["text_charset"]:
             x += 1
     return x / len(text)
 
@@ -321,9 +335,11 @@ def percentage_printable(text):
 def produce_plaintexts(ciphertext, keys, key_char_used):
     """
     Produce plaintext variant for each possible key,
-    creates csv files with keys, percentage of printable
+    creates csv files with keys, percentage of valid
     characters and used most frequent character
     """
+    global PARAMETERS
+    
     cleanup()
     mkdir(DIRNAME)
 
@@ -331,16 +347,16 @@ def produce_plaintexts(ciphertext, keys, key_char_used):
     # key can contain all kinds of characters
 
     fn_key_mapping = "filename-key.csv"
-    fn_perc_mapping = "filename-char_used-perc_printable.csv"
+    fn_perc_mapping = "filename-char_used-perc_valid.csv"
 
     key_mapping = open(os.path.join(DIRNAME,  fn_key_mapping), "w")
     perc_mapping = open(os.path.join(DIRNAME, fn_perc_mapping), "w")
 
     key_mapping.write("file_name;key_repr\n")
-    perc_mapping.write("file_name;char_used;perc_printable\n")
+    perc_mapping.write("file_name;char_used;perc_valid\n")
 
-    threshold_printable = 95
-    count_printable = 0
+    threshold_valid = 95
+    count_valid = 0
 
     for index, key in enumerate(keys):
         key_index = str(index).rjust(len(str(len(keys) - 1)), "0")
@@ -350,23 +366,25 @@ def produce_plaintexts(ciphertext, keys, key_char_used):
         file_name = os.path.join(DIRNAME, key_index + ".out")
 
         dexored = dexor(ciphertext, key)
-        perc = round(100 * percentage_printable(dexored))
-        if perc > threshold_printable:
-            count_printable += 1
+        perc = round(100 * percentage_valid(dexored))
+        if perc > threshold_valid:
+            count_valid += 1
         key_mapping.write("{};{}\n".format(file_name, key_repr))
         perc_mapping.write("{};{};{}\n".format(file_name,
                                                repr(key_char_used[key]),
                                                perc))
-        f = open(file_name, "wb")
-        f.write(dexored)
-        f.close()
+        if not PARAMETERS["filter_output"] or \
+            (PARAMETERS["filter_output"] and perc > threshold_valid):
+            f = open(file_name, "wb")
+            f.write(dexored)
+            f.close()
     key_mapping.close()
     perc_mapping.close()
 
-    s1 = C_COUNT + str(count_printable) + C_RESET
-    s2 = C_COUNT + str(round(threshold_printable)) + C_RESET
+    s1 = C_COUNT + str(count_valid) + C_RESET
+    s2 = C_COUNT + str(round(threshold_valid)) + C_RESET
 
-    print("Found {} plaintexts with {}%+ printable characters".format(s1, s2))
+    print("Found {} plaintexts with {}%+ valid characters".format(s1, s2))
     print("See files {}, {}".format(fn_key_mapping, fn_perc_mapping))
     return
 


### PR DESCRIPTION
**Use Case**: We have a plaintext encoded with another character set than all the printable charasters, e.g. Base64 or Base32. In the current version, `xortool` is not able to filter outputs based on the target charset.

**Solution**: Adding character set handling when checking for valid characters (which currently uses `string.printable`) and saving the outputs.

**New features**:
1. Charset handling while computing the percentage of valid characters
2. Output filtering based on the given charset (defaults to `printable` ; `printable`, `base32` and `base64` are currently supported)