### PR TITLE
Fix shebang for Arch Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 
 from distutils.core import setup

--- a/xortool/__init__.py
+++ b/xortool/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 
 __all__ = ["args", "colors", "libcolors", "routine"]

--- a/xortool/args.py
+++ b/xortool/args.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 
 from docopt import docopt

--- a/xortool/colors.py
+++ b/xortool/colors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 
 from xortool.libcolors import color

--- a/xortool/libcolors.py
+++ b/xortool/libcolors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 
 import os

--- a/xortool/routine.py
+++ b/xortool/routine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 
 import os

--- a/xortool/xortool
+++ b/xortool/xortool
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 """
 xortool

--- a/xortool/xortool-xor
+++ b/xortool/xortool-xor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding:utf-8 -*-
 
 """


### PR DESCRIPTION
See https://wiki.archlinux.org/index.php/python for the reason why: `python` on Arch Linux is `python3` instead of the assumed `python2` in this project.

This patch doesn't break the tool for other operating systems.