### PR TITLE
Enable Xortool to accept known plaintext for filtering output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ xortool
 
 Usage:
   xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
-  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
   xortool [-h | --help]
   xortool --version
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ xortool
 
 Usage:
   xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
   xortool [-h | --help]
   xortool --version
 
@@ -43,6 +43,7 @@ Options:
   -o --brute-printable              same as -b but will only check printable chars
   -f --filter-output                filter outputs based on the charset
   -t CHARSET --text-charset=CHARSET target text character set [default: printable]
+  -p PLAIN --known-plaintext=PLAIN  use known plaintext for decoding
   -h --help                         show this help
 
 Notes:
@@ -60,6 +61,7 @@ Examples:
   xortool -l 11 -c 20 file.bin
   xortool -x -c ' ' file.hex
   xortool -b -f -l 23 -t base64 message.enc
+  xortool -b -p "xctf{" message.enc
 ```
 
 Example 1

--- a/xortool/args.py
+++ b/xortool/args.py
@@ -46,6 +46,7 @@ def parse_parameters(doc, version):
             "max_key_length": parse_int(p["max-keylen"]),
             "most_frequent_char": parse_char(p["char"]),
             "text_charset": get_charset(p["text-charset"]),
+            "known_plain": p["known-plaintext"].encode() if p["known-plaintext"] else False,
         }
     except ValueError as err:
         raise ArgError(str(err))

--- a/xortool/xortool
+++ b/xortool/xortool
@@ -7,8 +7,8 @@ xortool
 
 Usage:
   xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
-  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
   xortool [-h | --help]
   xortool --version
 

--- a/xortool/xortool
+++ b/xortool/xortool
@@ -7,8 +7,8 @@ xortool
 
 Usage:
   xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-kp PLAIN] [FILE]
   xortool [-h | --help]
   xortool --version
 
@@ -21,6 +21,7 @@ Options:
   -o --brute-printable              same as -b but will only check printable chars
   -f --filter-output                filter outputs based on the charset
   -t CHARSET --text-charset=CHARSET target text character set [default: printable]
+  -p PLAIN --known-plaintext=PLAIN  use known plaintext for decoding
   -h --help                         show this help
 
 Notes:
@@ -372,6 +373,9 @@ def produce_plaintexts(ciphertext, keys, key_char_used):
         file_name = os.path.join(DIRNAME, key_index + ".out")
 
         dexored = dexor(ciphertext, key)
+        # ignore saving file when known plain is provided and output doesn't contain it
+        if PARAMETERS["known_plain"] and PARAMETERS["known_plain"] not in dexored:
+            continue
         perc = round(100 * percentage_valid(dexored))
         if perc > threshold_valid:
             count_valid += 1
@@ -388,6 +392,8 @@ def produce_plaintexts(ciphertext, keys, key_char_used):
     perc_mapping.close()
 
     fmt = "Found {C_COUNT}{:d}{C_RESET} plaintexts with {C_COUNT}{:d}{C_RESET}%+ valid characters"
+    if PARAMETERS["known_plain"]:
+        fmt += " which contained '{}'".format(PARAMETERS["known_plain"].decode('ascii'))
     print(fmt.format(count_valid, round(threshold_valid), **COLORS))
     print("See files {}, {}".format(fn_key_mapping, fn_perc_mapping))
 


### PR DESCRIPTION
In many CTFs, we know the flag format. For example: `xctf{`. With this simple option, we can limit outputs to contain valid answers:
`xortool xored_flag.bin -b -p "xctf{"`