### PR TITLE
Fix format string injection bug in --known-plaintext functionality

### DIFF
--- a/xortool/tool_main.py
+++ b/xortool/tool_main.py
@@ -393,6 +393,11 @@ def produce_plaintexts(ciphertext, keys, key_char_used):
 
     fmt = "Found {C_COUNT}{:d}{C_RESET} plaintexts with {C_COUNT}{:d}{C_RESET}%+ valid characters"
     if PARAMETERS["known_plain"]:
+        # If the known_plain parameter contains { or },
+        # it screws up the format string resulting in an exception.
+        # 
+        # Here we just escape the brackets and append to the new fmt string.
+        
         escaped_plain = PARAMETERS["known_plain"].decode('ascii')
         escaped_plain = escaped_plain.replace("{", "{{").replace("}", "}}")
 

--- a/xortool/tool_main.py
+++ b/xortool/tool_main.py
@@ -393,7 +393,10 @@ def produce_plaintexts(ciphertext, keys, key_char_used):
 
     fmt = "Found {C_COUNT}{:d}{C_RESET} plaintexts with {C_COUNT}{:d}{C_RESET}%+ valid characters"
     if PARAMETERS["known_plain"]:
-        fmt += " which contained '{}'".format(PARAMETERS["known_plain"].decode('ascii'))
+        escaped_plain = PARAMETERS["known_plain"].decode('ascii')
+        escaped_plain = escaped_plain.replace("{", "{{").replace("}", "}}")
+
+        fmt += " which contained '{}'".format(escaped_plain)
     print(fmt.format(count_valid, round(threshold_valid), **COLORS))
     print("See files {}, {}".format(fn_key_mapping, fn_perc_mapping))
 


### PR DESCRIPTION
Whenever a known plain-text string passed into --known-plaintext contains an angle bracket (`{` or `}`), it messes up a format string resulting in an exception.

```py
fmt = "Found {C_COUNT}{:d}{C_RESET} plaintexts with {C_COUNT}{:d}{C_RESET}%+ valid characters"
if PARAMETERS["known_plain"]:
    fmt += " which contained '{}'".format(PARAMETERS["known_plain"].decode('ascii'))
print(fmt.format(count_valid, round(threshold_valid), **COLORS))
```

To fix this, I simply just escaped any angle brackets in the `known_plain` parameter before appending to the format string.

```py
fmt = "Found {C_COUNT}{:d}{C_RESET} plaintexts with {C_COUNT}{:d}{C_RESET}%+ valid characters"
if PARAMETERS["known_plain"]:
    # If the known_plain parameter contains { or },
    # it screws up the format string resulting in an exception.
    # 
    # Here we just escape the brackets and append to the new fmt string.
        
    escaped_plain = PARAMETERS["known_plain"].decode('ascii')
    escaped_plain = escaped_plain.replace("{", "{{").replace("}", "}}")

    fmt += " which contained '{}'".format(escaped_plain)
print(fmt.format(count_valid, round(threshold_valid), **COLORS))
```