### PR TITLE
Option to allow adjustments to threshold_valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ xortool
 
 Usage:
   xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
-  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [-r PERCENT] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [-r PERCENT] [FILE]
   xortool [-h | --help]
   xortool --version
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
   -f --filter-output                filter outputs based on the charset
   -t CHARSET --text-charset=CHARSET target text character set [default: printable]
   -p PLAIN --known-plaintext=PLAIN  use known plaintext for decoding
+  -r PERCENT, --threshold=PERCENT   threshold validity percentage [default: 95]
   -h --help                         show this help
 
 Notes:
@@ -61,6 +62,7 @@ Examples:
   xortool -x -c ' ' file.hex
   xortool -b -f -l 23 -t base64 message.enc
   xortool -b -p "xctf{" message.enc
+  xortool -r 80 -p "flag{" -c ' ' message.enc
 ```
 
 Example 1

--- a/xortool/args.py
+++ b/xortool/args.py
@@ -47,6 +47,7 @@ def parse_parameters(doc, version):
             "most_frequent_char": parse_char(p["char"]),
             "text_charset": get_charset(p["text-charset"]),
             "known_plain": p["known-plaintext"].encode() if p["known-plaintext"] else False,
+            "threshold": parse_int(p["threshold"]),
         }
     except ValueError as err:
         raise ArgError(str(err))

--- a/xortool/tool_main.py
+++ b/xortool/tool_main.py
@@ -41,6 +41,7 @@ Examples:
   xortool -l 11 -c 20 file.bin
   xortool -x -c ' ' file.hex
   xortool -b -f -l 23 -t base64 message.enc
+  xortool -r 80 -p "flag{{" -c ' ' message.enc
 """
 
 from operator import itemgetter
@@ -48,10 +49,10 @@ import os
 import string
 import sys
 
-from xortool.args import(
+from xortools.args import(
     parse_parameters,
     ArgError,
-    )
+)
 
 from xortool.charset import CharsetError
 from xortool.colors import (

--- a/xortool/tool_main.py
+++ b/xortool/tool_main.py
@@ -7,9 +7,9 @@ xortool {__version__}
   - guess the key (base on knowledge of most frequent char)
 
 Usage:
-  xortool [-x] [-r PERCENT] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-r PERCENT] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
-  xortool [-x] [-r PERCENT] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
+  xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [-r PERCENT] [FILE]
+  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [-r PERCENT] [FILE]
   xortool [-h | --help]
   xortool --version
 
@@ -49,7 +49,7 @@ import os
 import string
 import sys
 
-from xortools.args import(
+from xortool.args import(
     parse_parameters,
     ArgError,
 )

--- a/xortool/tool_main.py
+++ b/xortool/tool_main.py
@@ -7,9 +7,9 @@ xortool {__version__}
   - guess the key (base on knowledge of most frequent char)
 
 Usage:
-  xortool [-x] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
-  xortool [-x] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
-  xortool [-x] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
+  xortool [-x] [-r PERCENT] [-m MAX-LEN] [-f] [-t CHARSET] [FILE]
+  xortool [-x] [-r PERCENT] [-l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
+  xortool [-x] [-r PERCENT] [-m MAX-LEN| -l LEN] [-c CHAR | -b | -o] [-f] [-t CHARSET] [-p PLAIN] [FILE]
   xortool [-h | --help]
   xortool --version
 
@@ -23,6 +23,7 @@ Options:
   -f --filter-output                filter outputs based on the charset
   -t CHARSET --text-charset=CHARSET target text character set [default: printable]
   -p PLAIN --known-plaintext=PLAIN  use known plaintext for decoding
+  -r PERCENT, --threshold=PERCENT   threshold validity percentage [default: 95]
   -h --help                         show this help
 
 Notes:
@@ -47,10 +48,11 @@ import os
 import string
 import sys
 
-from xortool.args import (
+from xortool.args import(
     parse_parameters,
     ArgError,
-)
+    )
+
 from xortool.charset import CharsetError
 from xortool.colors import (
     COLORS,
@@ -364,7 +366,12 @@ def produce_plaintexts(ciphertext, keys, key_char_used):
     key_mapping.write("file_name;key_repr\n")
     perc_mapping.write("file_name;char_used;perc_valid\n")
 
-    threshold_valid = 95
+    
+    if PARAMETERS["threshold"]:
+        threshold_valid = PARAMETERS["threshold"]
+    else:
+        threshold_valid = 95
+
     count_valid = 0
 
     for index, key in enumerate(keys):


### PR DESCRIPTION
In some CTF's  the value of threshold_valid can potentially be too high to be marked as a "found plaintext". Hoping to make it easier to adjust with this option.

xortool xored_flag.bin -r 85 -b -p "ctf{"